### PR TITLE
Modified VagrantConfig file

### DIFF
--- a/VagrantConfig.yaml
+++ b/VagrantConfig.yaml
@@ -1,0 +1,31 @@
+m1:
+  ip: 192.168.65.90
+  cpus: 2
+  memory: 1024
+  type: master
+a1:
+  ip: 192.168.65.111
+  cpus: 2
+  memory: 2048
+  memory-reserved: 512
+  type: agent-private
+a2:
+  ip: 192.168.65.121
+  cpus: 2
+  memory: 2048
+  memory-reserved: 512
+  type: agent-private
+p1:
+  ip: 192.168.65.60
+  cpus: 2
+  memory: 1536
+  memory-reserved: 512
+  type: agent-public
+  aliases:
+  - spring.acme.org
+  - oinker.acme.org
+boot:
+  ip: 192.168.65.50
+  cpus: 2
+  memory: 1024
+  type: boot


### PR DESCRIPTION
Has a lighter configuration in terms of CPU and Memory allocated, its enough for preliminary experiments and requires much less RAM than the other VagrantConfig-1m-2a-1p.yaml file.